### PR TITLE
Add tutorial notebook for public released truth-match catalog

### DIFF
--- a/notebooks/truth_match_table.ipynb
+++ b/notebooks/truth_match_table.ipynb
@@ -401,7 +401,76 @@
    "source": [
     "From the plot above, we see that at around $r = 27$, about half of the sources are \"detected\", in the sense that a good match in the Object Table is found. Much more sources fainter than $r = 27$ are not detected (or a match is not found). \n",
     "\n",
-    "On the bright end, the vast majority have good matches. A handful cases where there is no good matches or no matches are interesting blending study cases."
+    "On the bright end, the vast majority have good matches. A handful cases where there is no good matches or no matches are interesting blending study cases.\n",
+    "\n",
+    "Finally, recall that in the Object Table tutorial, we looked at the galaxy number density function. \n",
+    "We can now compare the truth galaxy number density function with the measured one! \n",
+    "\n",
+    "We will mostly follow the same procedure as in the Object Table tutorial. \n",
+    "We will estimate the sky area assuming a rectangular geometry of a single tract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "truth_galaxies = truth_cat.get_quantities(\n",
+    "    quantities=[\"mag_i\", \"ra\", \"dec\"], \n",
+    "    filters=[\"truth_type == 1\"], \n",
+    "    native_filters=[tract_filter(3830)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measured_galaxies = object_cat.get_quantities(\n",
+    "    quantities=[\"mag_i_cModel\"], \n",
+    "    filters=[\"extendedness == 1\", \"clean\", (np.isfinite, \"mag_i_cModel\")], \n",
+    "    native_filters=[tract_filter(3830)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d_ra = truth_galaxies[\"ra\"].max() - truth_galaxies[\"ra\"].min()\n",
+    "d_dec = truth_galaxies[\"dec\"].max() - truth_galaxies[\"dec\"].min()\n",
+    "cos_dec = np.cos(np.deg2rad(np.median(truth_galaxies[\"dec\"])))\n",
+    "sky_area_sq_arcmin = (d_ra * cos_dec * 60) * (d_dec * 60)\n",
+    "print(sky_area_sq_arcmin)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mag_bins = np.linspace(15, 30, 51)\n",
+    "\n",
+    "cdf_truth = np.searchsorted(truth_galaxies[\"mag_i\"], mag_bins, sorter=truth_galaxies[\"mag_i\"].argsort())\n",
+    "cdf_measured = np.searchsorted(measured_galaxies[\"mag_i_cModel\"], mag_bins, sorter=measured_galaxies[\"mag_i_cModel\"].argsort())\n",
+    "\n",
+    "fig, ax = plt.subplots(2, sharex=True, figsize=(6,5), gridspec_kw={\"hspace\": 0, \"height_ratios\": (3,1)}, dpi=100)\n",
+    "ax[0].semilogy(mag_bins, cdf_measured / sky_area_sq_arcmin, label=\"Measured\")\n",
+    "ax[0].semilogy(mag_bins, cdf_truth / sky_area_sq_arcmin, label=\"Truth\", ls=\"--\")\n",
+    "ax[1].set_xlabel(\"$i$-band cModel mag\");\n",
+    "ax[0].set_ylabel(\"Cumulative number per sq. arcmin\");\n",
+    "ax[1].semilogy(mag_bins, cdf_measured/cdf_truth)\n",
+    "ax[1].set_ylim(0.5, 2)\n",
+    "ax[0].legend();\n",
+    "\n",
+    "ax[0].grid();  # add grid to guide our eyes\n",
+    "ax[1].grid();"
    ]
   },
   {

--- a/notebooks/truth_match_table.ipynb
+++ b/notebooks/truth_match_table.ipynb
@@ -1,0 +1,436 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rubin LSST DESC DC2: Accessing Truth-match Table with GCRCatalogs\n",
+    "\n",
+    "**Authors**: Yao-Yuan Mao (@yymao), Javier Sanchez (@fjaviersanchez), Joanne Bogart (@JoanneBogart)\n",
+    "\n",
+    "This notebook will illustrate the basics of accessing the Truth-match Table, which contains the basic properties of truth objects (i.e., inputs to the image simulations) and also matching information with respect to the Object Table.\n",
+    "\n",
+    "**Prerequisite**: Please go over the Object Table tutorial first!  \n",
+    "\n",
+    "**Learning objectives**: After going through this notebook, you should be able to:\n",
+    "  1. Load and efficiently access a DC2 Truth-match Table with the GCRCatalogs\n",
+    "  2. Understand and have references for the Truth-match Table schema and data model\n",
+    "  3. Make some validation plots using the Truth-match Table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import necessary packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, \"/global/homes/y/yymao/desc/generic-catalog-reader/\")\n",
+    "sys.path.insert(0, \"/global/homes/y/yymao/desc/gcr-catalogs/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import GCRCatalogs\n",
+    "from GCRCatalogs.helpers.tract_catalogs import tract_filter, sample_filter\n",
+    "from GCRCatalogs import GCRQuery"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Access Truth-match Table with GCRCatalogs\n",
+    "\n",
+    "Just like the Object Table, the Truth-match Table is availble as parquet files, \n",
+    "and `GCRCatalogs` provides a high-level user interface for accessing it. \n",
+    "\n",
+    "However, while the Truth-match Table is a single set of parquet files, it appears as two entries in `GCRCatalogs` as we will see below. \n",
+    "\n",
+    "- The catalog entry `desc_dc2_run2.2i_dr6_truth` contains all truth information, including true sources that are not detected in the DR6 Object Table. \n",
+    "- The catalog entry `desc_dc2_run2.2i_dr6_object_with_truth_match` contains all the identical information of the Object Table (`desc_dc2_run2.2i_dr6_object`), plus additional columns that contain information of best-match truth objects. In other words, `desc_dc2_run2.2i_dr6_object_with_truth_match` is like a \"left join\" of `desc_dc2_run2.2i_dr6_object` and `desc_dc2_run2.2i_dr6_truth`, but with spatial sepration and magnitude difference as join keys. See the release note for further details. \n",
+    "\n",
+    "### Which catalog entry should I use?\n",
+    "\n",
+    "- If you don't need any truth information, just use `desc_dc2_run2.2i_dr6_object`. \n",
+    "- If you only need the best-match truth source information for each object (i.e., each row) in the Object Table, use `desc_dc2_run2.2i_dr6_object_with_truth_match`\n",
+    "- If you need more truth infomation beyond the best matches (i.e., undetected soruces, blended sources), you need to use `desc_dc2_run2.2i_dr6_truth`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GCRCatalogs.get_public_catalog_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GCRCatalogs.set_root_dir(\"/global/cfs/cdirs/lsst/gsharing/dc2_public/lsstdesc-dc2-wfd-dr6-v1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "object_cat = GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_object')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match_cat = GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_object_with_truth_match')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "truth_cat = GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_truth')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's first take a look at `match_cat` (which loads `desc_dc2_run2.2i_dr6_object_with_truth_match`). \n",
+    "As discussed earlier, this catalog is just Object Table plus best match truth information. \n",
+    "We can check if all the columns in the Object Table are present in this catalog too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set(object_cat.list_all_quantities()).issubset(match_cat.list_all_quantities())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Indeed `match_cat` contains all columns in the Object Table. So what are the additional columns? "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set(match_cat.list_all_quantities()).difference(object_cat.list_all_quantities())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These columns describe the infomation of the matched truth source for each object in the Object Table. \n",
+    "Note that most of these columns have a `_truth` postfix to avoid potential confusion with columns in the Object Table.\n",
+    "In fact, these columns are the same set of columns in `truth_cat` (but there's no `_truth` postfix in `truth_cat`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(truth_cat.list_all_quantities())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can verify what we just said is indeed true:\n",
+    "\n",
+    "additional_cols_in_match = set(match_cat.list_all_quantities()).difference(object_cat.list_all_quantities())\n",
+    "set(col[:-6] if col.endswith(\"_truth\") else col for col in additional_cols_in_match) == set(truth_cat.list_all_quantities())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What are \"best matches\"?\n",
+    "\n",
+    "Recall that `match_cat` is a \"left join\" of Object Table and Truth Table, so each object is assigned a \"best match\" truth soruce.\n",
+    "A \"best match\" truth soruce is the truth source that is within 1 arcsec of the object in consideration, and has the smallest magnitude difference.\n",
+    "If there's no truth sources that are within 1 arcses of the object in consideration, or if the smallest magnitude difference is larger than 1 mag, \n",
+    "then the \"best match\" would be just the nearest neighbor. \n",
+    "\n",
+    "If a best match satifies the two creteria (separation < 1 arcsec and magnidute difference <  1 mag), we call it a \"good match\". Otherwise, it would just be the nearest neighbor. Note that a \"good match\" could still (in fact, is likely to) be the nearest neighbor. \n",
+    "\n",
+    "Let's take a closer look. We can use the `is_good_match` and `is_nearest_neighbor` to tell whether the best match is a good match and/or the nearest neighbor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = match_cat.get_quantities([\"mag_r_cModel\", \"mag_r_truth\", \"match_sep\", \"is_good_match\", \"is_nearest_neighbor\"], native_filters=[tract_filter(3830)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that if the best match is not a good match, then it must be the nearest neighbor.\n",
+    "\n",
+    "(data[\"is_good_match\"] | data[\"is_nearest_neighbor\"]).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Most good matches should also be nearest neighbors. \n",
+    "# And \"not good\" matches can be due to either large separation or large magnitude difference. \n",
+    "\n",
+    "# Let's define a few masks to distinguish these cases:\n",
+    "\n",
+    "dmag = np.abs(data[\"mag_r_truth\"] - data[\"mag_r_cModel\"])\n",
+    "\n",
+    "good_and_nn = data[\"is_good_match\"] & data[\"is_nearest_neighbor\"]\n",
+    "good_not_nn = data[\"is_good_match\"] & (~data[\"is_nearest_neighbor\"])\n",
+    "not_good_small_dmag = (~data[\"is_good_match\"]) & (dmag < 1)\n",
+    "not_good_large_dmag = (~data[\"is_good_match\"]) & ((dmag >= 1) | np.isnan(dmag))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These four masks are mutually exclusive:\n",
+    "\n",
+    "(np.vstack([good_and_nn, good_not_nn, not_good_small_dmag, not_good_large_dmag]).astype(np.int).sum(axis=0) == 1).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sep_bins = np.linspace(0, 5, 51)\n",
+    "fig, ax = plt.subplots(ncols=2, figsize=(10, 4), dpi=100)\n",
+    "\n",
+    "hist = ax[0].hist(data[\"match_sep\"], bins=sep_bins)[0]\n",
+    "ax[0].set_yscale(\"log\");\n",
+    "ax[0].set_xlabel(\"separation [arcsec]\");\n",
+    "ax[0].set_ylabel(\"number (per bin)\");\n",
+    "\n",
+    "\n",
+    "bottom = None\n",
+    "for mask, color in zip(\n",
+    "    [good_and_nn, good_not_nn, not_good_small_dmag, not_good_large_dmag],\n",
+    "    [plt.cm.Greens(0.8), plt.cm.Greens(0.4), plt.cm.Oranges(0.4), plt.cm.Oranges(0.8)]\n",
+    "):\n",
+    "    frac = np.histogram(data[\"match_sep\"][mask], bins=sep_bins)[0] / hist\n",
+    "    ax[1].bar(sep_bins[:-1], frac, width=np.ediff1d(sep_bins), bottom=bottom, align=\"edge\", color=color)\n",
+    "    if bottom is None:\n",
+    "        bottom = frac\n",
+    "    else:\n",
+    "        bottom += frac\n",
+    "        \n",
+    "ax[1].set_xlabel(\"separation [arcsec]\");\n",
+    "ax[1].set_ylabel(\"fraction (per bin)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the figure above, the left panel shows the distribution of spatial separation for all best matches (note that y-axis is in log scale). \n",
+    "The vast majority of objects have matches within 1 arcsec, with a small tail goes to up to 5 arcsec. \n",
+    "\n",
+    "The right panel shows that, in each bin of spatial separation, the fraction of the four situations that we defined early. \n",
+    "The greens are \"good mathes\" (sep. < 1 arcsec and dmag < 1 mag), and we can see that the majority of \"good matches\" are also \n",
+    "nearest neighbor (darker green), especially if the separation is small. \n",
+    "The oranges are \"not good mathes\" (so that they are all nearest neighbors by definition).\n",
+    "About only 20% of these nearest neighbors but not good mathes have close magnitude (dmag < 1 mag). \n",
+    "\n",
+    "Let's also look at the measured vs. true magnitudes for these different matches. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(2, 2, figsize=(8, 8), dpi=100)\n",
+    "\n",
+    "for mask, color, label, ax_this in zip(\n",
+    "    [good_and_nn, good_not_nn, not_good_small_dmag, not_good_large_dmag],\n",
+    "    [plt.cm.Greens(0.8), plt.cm.Greens(0.4), plt.cm.Oranges(0.4), plt.cm.Oranges(0.8)],\n",
+    "    [\"good match\\nnearest neighbor\", \"good match\\nnot nearest neighbor\", \"not good match\\nnearest neighbor\\ndmag < 1\", \"not good match\\nnearest neighbor\\ndmag > 1\"],\n",
+    "    ax.flat\n",
+    "):\n",
+    "    ax_this.scatter(data[\"mag_r_truth\"][mask], data[\"mag_r_cModel\"][mask], color=color, s=0.005, rasterized=True)\n",
+    "    ax_this.set_xlim(15, 35)\n",
+    "    ax_this.set_ylim(15, 35)\n",
+    "    ax_this.plot([15, 35], [15, 35], color='grey', lw=0.5)\n",
+    "    ax_this.text(16, 34, label, va=\"top\")\n",
+    "    \n",
+    "fig.text(0.5, 0.02, \"true r-band mag\", ha=\"center\");\n",
+    "fig.text(0.02, 0.5, \"measured r-band mag\", va=\"center\", rotation=90);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that because `match_cat` uses the Object Table as the reference catalog for the match, a unique truth source may appear twice in the catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "truth_id = match_cat.get_quantities([\"id_truth\"], native_filters=tract_filter(3830))[\"id_truth\"]\n",
+    "\n",
+    "number_of_objects = len(truth_id)\n",
+    "number_of_unique_truth = len(np.unique(truth_id))\n",
+    "\n",
+    "print(\"Number of objects\", number_of_objects)\n",
+    "print(\"Number of unique truth sources\", number_of_unique_truth)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Truth Table\n",
+    "\n",
+    "Now we switch to look at the full truth table `truth_cat`. When using `truth_cat`, you will obtain all truth sources, including those below the detection limit or blended. You will also obtain only *unique* truth sources (unlike the case of `match_cat` as we shown above). \n",
+    "\n",
+    "The Truth Table allows us to inspect, for example, undetected sources. \n",
+    "Here, let's look at how many truth galaxies are detected (and not blended) as a function of the galaxy magnitude. \n",
+    "\n",
+    "To select only galaxies, we can filter on `truth_type == 1`. Here the truth type is 1 for galaxies, 2 for stars, and 3 for SNe. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "truth_galaxies = truth_cat.get_quantities(\n",
+    "    quantities=[\"match_objectId\", \"is_good_match\", \"mag_r\"], \n",
+    "    filters=[\"truth_type == 1\"], \n",
+    "    native_filters=[tract_filter(3830)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mag_bins = np.linspace(14.5, 29.5, 46)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6,4), dpi=100)\n",
+    "\n",
+    "ax.hist(truth_galaxies[\"mag_r\"][truth_galaxies[\"is_good_match\"]], mag_bins, histtype=\"step\", label=\"has good match\", lw=1.5, color=\"C2\");\n",
+    "ax.hist(truth_galaxies[\"mag_r\"][(~truth_galaxies[\"is_good_match\"]) & (truth_galaxies[\"match_objectId\"] > -1)], mag_bins, histtype=\"step\", label=\"has NN (but not good) match\", lw=1.5, color=\"C1\");\n",
+    "ax.hist(truth_galaxies[\"mag_r\"][truth_galaxies[\"match_objectId\"] == -1], mag_bins, histtype=\"step\", label=\"has no matches at all\", lw=1.5, color=\"C3\");\n",
+    "\n",
+    "ax.set_yscale(\"log\");\n",
+    "ax.legend(loc=\"upper left\");\n",
+    "ax.set_xlabel(\"r-band mag\");\n",
+    "ax.set_ylabel(\"number per bin\");\n",
+    "ax.set_xticks(np.arange(14, 31));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the plot above, we see that at around $r = 27$, about half of the sources are \"detected\", in the sense that a good match in the Object Table is found. Much more sources fainter than $r = 27$ are not detected (or a match is not found). \n",
+    "\n",
+    "On the bright end, the vast majority have good matches. A handful cases where there is no good matches or no matches are interesting blending study cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "desc-python-bleed",
+   "language": "python",
+   "name": "desc-python-bleed"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/truth_match_table.ipynb
+++ b/notebooks/truth_match_table.ipynb
@@ -64,19 +64,19 @@
    "source": [
     "## Access Truth-match Table with GCRCatalogs\n",
     "\n",
-    "Just like the Object Table, the Truth-match Table is availble as parquet files, \n",
+    "Just like the Object Table, the Truth-match Table is available as parquet files, \n",
     "and `GCRCatalogs` provides a high-level user interface for accessing it. \n",
     "\n",
     "However, while the Truth-match Table is a single set of parquet files, it appears as two entries in `GCRCatalogs` as we will see below. \n",
     "\n",
     "- The catalog entry `desc_dc2_run2.2i_dr6_truth` contains all truth information, including true sources that are not detected in the DR6 Object Table. \n",
-    "- The catalog entry `desc_dc2_run2.2i_dr6_object_with_truth_match` contains all the identical information of the Object Table (`desc_dc2_run2.2i_dr6_object`), plus additional columns that contain information of best-match truth objects. In other words, `desc_dc2_run2.2i_dr6_object_with_truth_match` is like a \"left join\" of `desc_dc2_run2.2i_dr6_object` and `desc_dc2_run2.2i_dr6_truth`, but with spatial sepration and magnitude difference as join keys. See the release note for further details. \n",
+    "- The catalog entry `desc_dc2_run2.2i_dr6_object_with_truth_match` contains all the identical information of the Object Table (`desc_dc2_run2.2i_dr6_object`), plus additional columns that contain information of best-match truth objects. In other words, `desc_dc2_run2.2i_dr6_object_with_truth_match` is like a \"left join\" of `desc_dc2_run2.2i_dr6_object` and `desc_dc2_run2.2i_dr6_truth`, but with spatial separation and magnitude difference as join keys. See the release note for further details. \n",
     "\n",
     "### Which catalog entry should I use?\n",
     "\n",
     "- If you don't need any truth information, just use `desc_dc2_run2.2i_dr6_object`. \n",
     "- If you only need the best-match truth source information for each object (i.e., each row) in the Object Table, use `desc_dc2_run2.2i_dr6_object_with_truth_match`\n",
-    "- If you need more truth infomation beyond the best matches (i.e., undetected soruces, blended sources), you need to use `desc_dc2_run2.2i_dr6_truth`"
+    "- If you need more truth infomation beyond the best matches (i.e., undetected sources, blended sources), you need to use `desc_dc2_run2.2i_dr6_truth`"
    ]
   },
   {
@@ -163,7 +163,7 @@
    "metadata": {},
    "source": [
     "These columns describe the infomation of the matched truth source for each object in the Object Table. \n",
-    "Note that most of these columns have a `_truth` postfix to avoid potential confusion with columns in the Object Table.\n",
+    "Note that most of these columns have a `_truth` postfix (i.e., suffix) to avoid potential confusion with columns in the Object Table.\n",
     "In fact, these columns are the same set of columns in `truth_cat` (but there's no `_truth` postfix in `truth_cat`):"
    ]
   },
@@ -194,12 +194,12 @@
    "source": [
     "### What are \"best matches\"?\n",
     "\n",
-    "Recall that `match_cat` is a \"left join\" of Object Table and Truth Table, so each object is assigned a \"best match\" truth soruce.\n",
-    "A \"best match\" truth soruce is the truth source that is within 1 arcsec of the object in consideration, and has the smallest magnitude difference.\n",
-    "If there's no truth sources that are within 1 arcses of the object in consideration, or if the smallest magnitude difference is larger than 1 mag, \n",
+    "Recall that `match_cat` is a \"left join\" of Object Table and Truth Table, so each object is assigned a \"best match\" truth source.\n",
+    "A \"best match\" truth source is the truth source that is within 1 arcsec of the object in consideration, and has the smallest magnitude difference.\n",
+    "If there's no truth sources that are within 1 arcsec of the object in consideration, or if the smallest magnitude difference is larger than 1 mag, \n",
     "then the \"best match\" would be just the nearest neighbor. \n",
     "\n",
-    "If a best match satifies the two creteria (separation < 1 arcsec and magnidute difference <  1 mag), we call it a \"good match\". Otherwise, it would just be the nearest neighbor. Note that a \"good match\" could still (in fact, is likely to) be the nearest neighbor. \n",
+    "If a best match satisfies the two criteria (separation < 1 arcsec and magnitude difference <  1 mag), we call it a \"good match\". Otherwise, it would just be the nearest neighbor. Note that a \"good match\" could still (in fact, is likely to) be the nearest neighbor. \n",
     "\n",
     "Let's take a closer look. We can use the `is_good_match` and `is_nearest_neighbor` to tell whether the best match is a good match and/or the nearest neighbor."
    ]
@@ -293,10 +293,10 @@
     "The vast majority of objects have matches within 1 arcsec, with a small tail goes to up to 5 arcsec. \n",
     "\n",
     "The right panel shows that, in each bin of spatial separation, the fraction of the four situations that we defined early. \n",
-    "The greens are \"good mathes\" (sep. < 1 arcsec and dmag < 1 mag), and we can see that the majority of \"good matches\" are also \n",
+    "The greens bars denote \"good matches\" (sep. < 1 arcsec and dmag < 1 mag), and we can see that the majority of \"good matches\" are also \n",
     "nearest neighbor (darker green), especially if the separation is small. \n",
-    "The oranges are \"not good mathes\" (so that they are all nearest neighbors by definition).\n",
-    "About only 20% of these nearest neighbors but not good mathes have close magnitude (dmag < 1 mag). \n",
+    "The oranges bars denote \"not good matches\" (so that they are all nearest neighbors by definition).\n",
+    "About only 20% of these nearest neighbors but not good matches have close magnitude (dmag < 1 mag). \n",
     "\n",
     "Let's also look at the measured vs. true magnitudes for these different matches. "
    ]

--- a/notebooks/truth_match_table.ipynb
+++ b/notebooks/truth_match_table.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "GCRCatalogs.set_root_dir(\"/global/cfs/cdirs/lsst/gsharing/dc2_public/lsstdesc-dc2-wfd-dr6-v1\")"
+    "GCRCatalogs.set_root_dir(\"/global/cfs/cdirs/lsst/gsharing\")"
    ]
   },
   {

--- a/notebooks/truth_match_table.ipynb
+++ b/notebooks/truth_match_table.ipynb
@@ -230,17 +230,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Most good matches should also be nearest neighbors. \n",
-    "# And \"not good\" matches can be due to either large separation or large magnitude difference. \n",
+    "# Most \"good matches\" (sep. < 1 arcsec, dmag < 1 mag) would also happen to be nearest neighbors (NN). \n",
+    "# \"Not good\" matches can be due to either large separation or large magnitude difference. \n",
     "\n",
     "# Let's define a few masks to distinguish these cases:\n",
     "\n",
     "dmag = np.abs(data[\"mag_r_truth\"] - data[\"mag_r_cModel\"])\n",
     "\n",
-    "good_and_nn = data[\"is_good_match\"] & data[\"is_nearest_neighbor\"]\n",
-    "good_not_nn = data[\"is_good_match\"] & (~data[\"is_nearest_neighbor\"])\n",
-    "not_good_small_dmag = (~data[\"is_good_match\"]) & (dmag < 1)\n",
-    "not_good_large_dmag = (~data[\"is_good_match\"]) & ((dmag >= 1) | np.isnan(dmag))"
+    "good_and_nn = data[\"is_good_match\"] & data[\"is_nearest_neighbor\"]     # Good matches that happen to be the nearest neighbor (NN) too\n",
+    "good_not_nn = data[\"is_good_match\"] & (~data[\"is_nearest_neighbor\"])  # Good matches that are not the nearest neighbor (NN)\n",
+    "not_good_small_dmag = (~data[\"is_good_match\"]) & (dmag < 1)           # Not good matches that have dmag < 1 mag (so they must have sep > 1 arcsec)\n",
+    "not_good_large_dmag = (~data[\"is_good_match\"]) & ((dmag >= 1) | np.isnan(dmag))  # Not good matches that have dmag > 1 mag or undefined mag"
    ]
   },
   {


### PR DESCRIPTION
This PR adds a tutorial notebook for public released truth-match catalog. Similar to #1, one needs to get GCR v0.9.2 and also gcr-catalogs master + LSSTDESC/gcr-catalogs#523 + LSSTDESC/gcr-catalogs#524 for this notebook to run. 

The notebook can also use some polish and maybe a few more science examples. I am running of great ideas at this moment so I am opening this PR for people to review and make suggestions.

